### PR TITLE
Increase test coverage for patient command classes in logic

### DIFF
--- a/src/main/java/team/baymax/logic/commands/patient/AddPatientCommand.java
+++ b/src/main/java/team/baymax/logic/commands/patient/AddPatientCommand.java
@@ -21,7 +21,7 @@ public class AddPatientCommand extends Command {
 
     public static final String COMMAND_WORD = "addPatient";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the appointment book. "
             + "Parameters: "
             + PREFIX_NRIC + "Nric "
             + PREFIX_NAME + "NAME "
@@ -37,7 +37,7 @@ public class AddPatientCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PATIENT = "This patient already exists in the appointment book";
 
     private final Patient toAdd;
 

--- a/src/main/java/team/baymax/model/util/SampleDataUtil.java
+++ b/src/main/java/team/baymax/model/util/SampleDataUtil.java
@@ -21,18 +21,18 @@ public class SampleDataUtil {
     public static Patient[] getSamplePatients() {
         return new Patient[] {
             new Patient(new Nric("S0123456A"), new Name("Alex Yeoh"), new Phone("87438807"),
-                    new Gender("M"), getTagSet(""), new Remark("Allergic to ibuprofen.")),
+                    new Gender("M"), getTagSet(), new Remark("Allergic to ibuprofen.")),
             new Patient(new Nric("T0123456A"), new Name("Bernice Yu"), new Phone("99272758"),
-                    new Gender("F"), getTagSet("", ""),
+                    new Gender("F"), getTagSet(),
                     new Remark("Only available on Saturdays.")),
             new Patient(new Nric("S6543210A"), new Name("Charlotte Oliveiro"), new Phone("93210283"),
-                    new Gender("F"), getTagSet(""), new Remark("Under long term care.")),
+                    new Gender("F"), getTagSet(), new Remark("Under long term care.")),
             new Patient(new Nric("T6543210A"), new Name("David Li"), new Phone("91031282"),
-                    new Gender("M"), getTagSet(""), new Remark("Diabetic.")),
+                    new Gender("M"), getTagSet(), new Remark("Diabetic.")),
             new Patient(new Nric("T1548765D"), new Name("Irfan Ibrahim"), new Phone("92492021"),
-                    new Gender("M"), getTagSet(""), new Remark("Allergic to aspirin.")),
+                    new Gender("M"), getTagSet(), new Remark("Allergic to aspirin.")),
             new Patient(new Nric("S4658753E"), new Name("Roy Balakrishnan"), new Phone("92624417"),
-                    new Gender("M"), getTagSet(""), new Remark("Currently taking warfarin."))
+                    new Gender("M"), getTagSet(), new Remark("Currently taking warfarin."))
         };
     }
 

--- a/src/test/java/team/baymax/logic/commands/patient/ListPatientCommandTest.java
+++ b/src/test/java/team/baymax/logic/commands/patient/ListPatientCommandTest.java
@@ -1,5 +1,7 @@
 package team.baymax.logic.commands.patient;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static team.baymax.logic.commands.patient.PatientCommandTestUtil.showPatientAtIndex;
 import static team.baymax.testutil.TypicalIndexes.INDEX_FIRST_PATIENT;
 import static team.baymax.testutil.TypicalPatients.getTypicalPatientManager;
@@ -37,5 +39,18 @@ public class ListPatientCommandTest {
         showPatientAtIndex(model, INDEX_FIRST_PATIENT);
         PatientCommandTestUtil.assertPatientCommandSuccess(new ListPatientCommand(), model,
                 ListPatientCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ListPatientCommand listPatientCommand = new ListPatientCommand();
+        // null -> false
+        assertFalse(listPatientCommand.equals(null));
+        // different types -> false
+        assertFalse(listPatientCommand.equals(1));
+        // same type -> true
+        assertTrue(listPatientCommand.equals(new ListPatientCommand()));
+
+        assertTrue(listPatientCommand.equals(listPatientCommand));
     }
 }

--- a/src/test/java/team/baymax/logic/commands/patient/RemarkPatientCommandTest.java
+++ b/src/test/java/team/baymax/logic/commands/patient/RemarkPatientCommandTest.java
@@ -1,5 +1,8 @@
 package team.baymax.logic.commands.patient;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 import team.baymax.model.Model;
@@ -33,5 +36,25 @@ class RemarkPatientCommandTest {
         expectedModel.setPatient(firstPatient, editedPatient);
 
         PatientCommandTestUtil.assertPatientCommandSuccess(remarkPatientCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        Patient patient = new PatientBuilder().build();
+        RemarkPatientCommand remarkPatientCommandA = new RemarkPatientCommand(TypicalIndexes.INDEX_FIRST_PATIENT,
+                new Remark(REMARK_STUB));
+        RemarkPatientCommand remarkPatientCommandB = new RemarkPatientCommand(TypicalIndexes.INDEX_SECOND_PATIENT,
+                patient.getRemark());
+        // null -> false
+        assertFalse(remarkPatientCommandA.equals(null));
+        // different type -> false
+        assertFalse(remarkPatientCommandA.equals(1));
+        // this -> true
+        assertTrue(remarkPatientCommandA.equals(remarkPatientCommandA));
+        // remark command but with different state-> false
+        assertFalse(remarkPatientCommandA.equals(remarkPatientCommandB));
+        // remark command with same state -> true
+        assertTrue(remarkPatientCommandB.equals(new RemarkPatientCommand(TypicalIndexes.INDEX_SECOND_PATIENT,
+                patient.getRemark())));
     }
 }


### PR DESCRIPTION
Increased test coverage for ListPatientCommand and RemarkPatientCommand.

![image](https://user-images.githubusercontent.com/66032473/96277128-70029e00-1006-11eb-85f5-3e5c1b8efd79.png)
